### PR TITLE
Update Helm provider version to 2.12.1

### DIFF
--- a/tf-head-services/provider.tf-os
+++ b/tf-head-services/provider.tf-os
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 1.0.0, < 3.0.0"
+      version = "2.12.1"
     }
   }
 }


### PR DESCRIPTION
Pin Helm provider to 2.x:

Helm provider 1.x does not support block-based set { ... } syntax, nor does it support pulling charts from OCI (oci://) registries, which are required by our current chart sources and module code.

Helm provider 3.x introduces new breaking changes and features based on the latest Terraform plugin framework and may change provider behaviors or HCL expectations in ways that have not been tested or verified in our current stack. Pinning to 2.x ensures continued compatibility with our existing modules and avoids unexpected errors, which i encoutered deploying this project Helm provider 2.x is the first version line that supports both set { ... } block syntax and oci:// registry protocol for Helm charts, making it the correct baseline for this repo’s required features.