### PR TITLE
Change Terraform commands to Tofu commands

### DIFF
--- a/HELM.md
+++ b/HELM.md
@@ -46,7 +46,7 @@ Required variables for AWS:
      * sender_email_password - password for SMTP sender account (required for encrypted communication)
 
 3. Initialize Terraform:\
-`terraform init`
+`tofu init`
 
 4. Deploy Helm packages:\
-`terraform apply -var-file tfvars/deployment.tfvars`
+   `tofu apply -var-file tfvars/deployment.tfvars`


### PR DESCRIPTION
Updated commands from 'terraform' to 'tofu' for initialization and deployment.

Update Terraform commands to Tofu commands
The beginning , we install tofu classic here: https://github.com/cyberrangecz/devops-tf-deployment?tab=readme-ov-file, switching to terraform on this part may cause unexpected errors (it did for me), but staying with tofu works when you run tofu apply.

For consistency and to avoid errors, we recommend staying with tofu instead of installing both tofu and terraform since there mught be subtle differences that makes deployments fail unexpectedly